### PR TITLE
JSR-356 Client - Add Support for Async Calls

### DIFF
--- a/modules/swaggersocket-java-jsr356-client/src/main/java/io/swagger/swaggersocket/java/jsr356/client/JSR356SwaggerSocketClient.java
+++ b/modules/swaggersocket-java-jsr356-client/src/main/java/io/swagger/swaggersocket/java/jsr356/client/JSR356SwaggerSocketClient.java
@@ -19,6 +19,7 @@ import io.swagger.swaggersocket.protocol.Request;
 import io.swagger.swaggersocket.protocol.Response;
 
 import java.util.List;
+import java.util.concurrent.Future;
 
 public interface JSR356SwaggerSocketClient {
 
@@ -35,6 +36,14 @@ public interface JSR356SwaggerSocketClient {
     <T> List<T> send(List<Request> requests, Class<T> resultClass);
 
     <T> T send(Request request, Class<T> resultClass);
+
+    Future<Response> sendAsync(Request request);
+
+    List<Future<Response>> sendAsync(List<Request> requests);
+
+    <T> List<Future<T>> sendAsync(List<Request> requests, Class<T> resultClass);
+
+    <T> Future<T> sendAsync(Request request, Class<T> resultClass);
 
     void close();
 

--- a/modules/swaggersocket-java-jsr356-client/src/test/resources/logback.xml
+++ b/modules/swaggersocket-java-jsr356-client/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
-Added additional methods to return Future<Response> or Future<T>
to allow for asynchronous calling when using the JSR-356 client.

The user can now choose which is best suited for their use case

-Tests were added for each of the new methods

-Also added a test logback.xml to reduce a tremendous amount of
debug log spam from the embedded tomcat container when running
the tests
